### PR TITLE
Add a command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,46 @@ If using, the development version, you might want to install dependencies as wel
 Usage Example
 =============
 
-In this example we are exporting a 300 dpi and 30x20 cm image of the [Paris flood map](https://aromeu.carto.com/builder/87c5667f-3eb5-4a19-9300-b39a2d1970d1/embed)
+Command Line Tool
+-----------------
+
+```
+usage: carto-print [-h] [--api-key API_KEY] [--dpi DPI] [--img-format FORMAT]
+                   [--output-dir DIR] [--server-url URL]
+                   USER MAP_TPL WIDTH_CM HEIGHT_CM ZOOM BOUNDING_BOX
+
+Exports images at any resolution, size and bounding box from a CARTO named
+map.
+
+positional arguments:
+  USER                 CARTO user name
+  MAP_TPL              map template or named map name
+  WIDTH_CM             width in cm
+  HEIGHT_CM            height in cm
+  ZOOM                 zoom level
+  BOUNDING_BOX         bounding box: south,west,north,east (min lat, min lon,
+                       max lat, max lon)
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --api-key API_KEY    CARTO api_key (default: default_public)
+  --dpi DPI            output image DPI (default: 72)
+  --img-format FORMAT  output image format: RGBA, CMYK (default: RGBA)
+  --output-dir DIR     output directory (default: current one)
+  --server-url URL     server base URL, should contain the token {username}
+                       (default: https://{username}.carto.com)
+```
+
+In this example we are exporting a 300 dpi and 30x20 cm image of the [Paris flood map](https://aromeu.carto.com/builder/87c5667f-3eb5-4a19-9300-b39a2d1970d1/embed):
+
+```
+carto-print aromeu tpl_87c5667f_3eb5_4a19_9300_b39a2d1970d1 30 20 12 1.956253,48.711127,2.835159,49.012429 --dpi 300 --img-format CMYK --output-dir /tmp
+```
+
+Library
+-------
+
+The previous example calling directly the library would be as follows:
 
 ```python
 from carto.print import Printer
@@ -37,11 +76,12 @@ printer.export('/tmp')
 
 Where the signature of the `Printer` constructor is as follows:
 
-```
+```python
 Printer(CARTO_USER_NAME, MAP_ID, CARTO_API_KEY, WIDTH_CM, HEIGHT_CM, ZOOM_LEVEL, BOUNDING_BOX, DPI, IMAGE_FORMAT)
 ```
 
 Where `IMAGE_FORMAT` is one of `RGBA` or `CMYK`
+
 
 Known Issues
 ============

--- a/bin/carto-print
+++ b/bin/carto-print
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+
+from carto.print import IMAGE_MODES, DEFAULT_SERVER_URL, Printer
+
+
+DEFAULT_API_KEY = 'default_public'
+DEFAULT_DPI = 72
+
+
+def bbox_check(bbox):
+    bbox_pts = bbox.split(',')
+
+    # Check that we have 4 values
+    if len(bbox_pts) != 4:
+        raise argparse.ArgumentTypeError('Bounding box must have 4 points.')
+
+    # Check that the values are floats
+    try:
+        min_lat, min_lon, max_lat, max_lon = map(float, bbox_pts)
+    except ValueError:
+        raise argparse.ArgumentTypeError('Bounding box points must be floats.')
+
+    # Check that the points are in range
+    if not -90 <= min_lat <= 90:
+        raise argparse.ArgumentTypeError('Bounding box south (min lat) point must be in the [-90,90] range.')
+
+    if not -90 <= max_lat <= 90:
+        raise argparse.ArgumentTypeError('Bounding box north (max lat) point must be in the [-90,90] range.')
+
+    if not -180 <= min_lon <= 180:
+        raise argparse.ArgumentTypeError('Bounding box west (min lon) point must be in the [-180,180] range.')
+
+    if not -180 <= max_lon <= 180:
+        raise argparse.ArgumentTypeError('Bounding box east (max lon) point must be in the [-180,180] range.')
+
+    # Check that max are greater than mins
+    if min_lat >= max_lat:
+        raise argparse.ArgumentTypeError('Bounding box north (max lat) point must be greater than the south (min lat) one.')
+
+    if min_lon >= max_lon:
+        raise argparse.ArgumentTypeError('Bounding box east (max lon) point must be greater than the west (min lon) one.')
+
+    return bbox
+
+
+def writable_dir(directory):
+    if not os.access(directory, os.W_OK):
+        raise argparse.ArgumentTypeError('Output directory must be writable by the user.')
+
+    return directory
+
+
+parser = argparse.ArgumentParser(
+    description='Exports images at any resolution, size and bounding box from a CARTO named map.'
+)
+
+parser.add_argument('user', metavar='USER', type=str,
+                    help='CARTO user name')
+
+parser.add_argument('map_tpl', metavar='MAP_TPL', type=str,
+                    help='map template or named map name')
+
+parser.add_argument('width', metavar='WIDTH_CM', type=int,
+                    help='width in cm')
+
+parser.add_argument('height', metavar='HEIGHT_CM', type=int,
+                    help='height in cm')
+
+parser.add_argument('zoom', metavar='ZOOM', type=int,
+                    help='zoom level')
+
+parser.add_argument('bbox', metavar='BOUNDING_BOX', type=bbox_check,
+                    help='bounding box: south,west,north,east (min lat, min lon, max lat, max lon)')
+
+parser.add_argument('--api-key', metavar='API_KEY', type=str, default=DEFAULT_API_KEY,
+                    help='CARTO api_key (default: {})'.format(DEFAULT_API_KEY))
+
+parser.add_argument('--dpi', metavar='DPI', type=int, default=DEFAULT_DPI,
+                    help='output image DPI (default: {})'.format(DEFAULT_DPI))
+
+parser.add_argument('--img-format', metavar='FORMAT', type=str, default=IMAGE_MODES[0], choices=IMAGE_MODES,
+                    help='output image format: {} (default: {})'.format(', '.join(IMAGE_MODES), IMAGE_MODES[0]))
+
+parser.add_argument('--output-dir', metavar='DIR', type=writable_dir, default=os.getcwd(),
+                    help='output directory (default: current one)')
+
+parser.add_argument('--server-url', metavar='URL', type=str, default=DEFAULT_SERVER_URL,
+                    help='server base URL, should contain the token {{username}} (default: {})'.format(DEFAULT_SERVER_URL))
+
+
+args = parser.parse_args()
+
+printer = Printer(args.user, args.map_tpl, args.api_key,
+                  args.width, args.height, args.zoom, args.bbox,
+                  args.dpi, args.img_format, args.server_url)
+
+print("Exporting...")
+print("Exported! Output file: {}".format(printer.export(args.output_dir)))

--- a/carto/print.py
+++ b/carto/print.py
@@ -21,6 +21,7 @@ DEFAULT_PRINT_TILE_SIZE = 2048
 MAX_TILE_SIZE = 8192
 DEFAULT_DPI = 72.0
 DEFAULT_SERVER_URL = 'https://{username}.carto.com'
+IMAGE_MODES = ['RGBA', 'CMYK']
 
 def latlon_2_pixels(lat, lon, z):
     initialResolution = 2 * math.pi * EARTH_RADIUS / DEFAULT_TILE_SIZE
@@ -170,7 +171,7 @@ class Printer(object):
         return '_'.join(anything.split('-')).strip()
 
     def validate_mode(self):
-        if self.mode not in ['RGBA', 'CMYK']:
+        if self.mode not in IMAGE_MODES:
             raise Exception('mode not supported')
 
     def get_format(self):

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@ setup(name="carto-print",
       version="0.0.3",
       url="https://github.com/CartoDB/carto-print",
       install_requires=required,
-      packages=["carto"])
+      packages=["carto"],
+      scripts=["bin/carto-print"])


### PR DESCRIPTION
This PR adds a simple command line tool to make easier the usage.

The command line does the following checks over the input arguments:

- `width`, `height` and `zoom` must be  `int`.
- The image mode must be `RGBA`, `CMYK` (this was already checked).
- The following bounding box checks:
  - Check that the bbox has 4 points.
  - Check that the bbox points are `float`.
  - Ranges for each element (`lat` must be in [-90,90], `lng` must be in [-180,180]).
  - Check that the max `lat`/`lng` is greater than the min `lat`/`lng`.
- The output directory for the image must be user writable.

Something I'm not 100% sure... We are using `south,west,north,east (min lat,min lon,max lat,max lon)` as the bounding box format, right?